### PR TITLE
Patched the "update-vector-store" and moved the whole function that creates vector stores from rm.py to utils.py

### DIFF
--- a/examples/README.md
+++ b/examples/README.md
@@ -83,7 +83,7 @@ By default, STORM is grounded on the Internet using the search engine, but it ca
    - Run the following command under the root directory to downsample the dataset by filtering papers with terms `[cs.CV]` and get a csv file that match the format mentioned above.
 
      ```
-     python examples/helper/process_kaggle_arxiv_abstract_dataset --input-path $PATH_TO_THE_DOWNLOADED_FILE --output-path $PATH_TO_THE_PROCESSED_CSV
+     python examples/helper/process_kaggle_arxiv_abstract_dataset.py --input-path $PATH_TO_THE_DOWNLOADED_FILE --output-path $PATH_TO_THE_PROCESSED_CSV
      ```
    - Run the following command to run STORM grounding on the processed dataset. You can input a topic related to computer vision (e.g., "The progress of multimodal models in computer vision") to see the generated article. (Note that the generated article may not include enough details since the quick test only use the abstracts of arxiv papers.)
 

--- a/examples/README.md
+++ b/examples/README.md
@@ -54,7 +54,6 @@ By default, STORM is grounded on the Internet using the search engine, but it ca
        --output-dir $OUTPUT_DIR \
        --vector-db-mode offline \
        --offline-vector-db-dir $OFFLINE_VECTOR_DB_DIR \
-       --update-vector-store \
        --csv-file-path $CSV_FILE_PATH \ 
        --device $DEVICE_FOR_EMBEDDING(mps, cuda, cpu) \
        --do-research \
@@ -70,7 +69,6 @@ By default, STORM is grounded on the Internet using the search engine, but it ca
        --output-dir $OUTPUT_DIR \
        --vector-db-mode online \
        --online-vector-db-url $ONLINE_VECTOR_DB_URL \
-       --update-vector-store \
        --csv-file-path $CSV_FILE_PATH \
        --device $DEVICE_FOR_EMBEDDING(mps, cuda, cpu) \
        --do-research \
@@ -94,7 +92,6 @@ By default, STORM is grounded on the Internet using the search engine, but it ca
          --output-dir $OUTPUT_DIR \
          --vector-db-mode offline \
          --offline-vector-db-dir $OFFLINE_VECTOR_DB_DIR \
-         --update-vector-store \
          --csv-file-path $PATH_TO_THE_PROCESSED_CSV \
          --device $DEVICE_FOR_EMBEDDING(mps, cuda, cpu) \
          --do-research \

--- a/examples/run_storm_wiki_gpt_with_VectorRM.py
+++ b/examples/run_storm_wiki_gpt_with_VectorRM.py
@@ -93,7 +93,7 @@ def main(args):
         rm.init_online_vector_db(url=args.online_vector_db_url, api_key=os.getenv('QDRANT_API_KEY'))
 
     # Update the vector store with the documents in the csv file
-    if args.update_vector_store:
+    if args.csv_file_path:
         rm.update_vector_store(
             file_path=args.csv_file_path,
             content_column='content',
@@ -139,10 +139,7 @@ if __name__ == "__main__":
                         help='If use offline mode, please provide the directory to store the vector store.')
     parser.add_argument('--online-vector-db-url', type=str,
                         help='If use online mode, please provide the url of the Qdrant server.')
-    parser.add_argument('--update-vector-store', action='store_true',
-                        help='If True, update the vector store with the documents in the csv file; otherwise, '
-                             'use the existing vector store.')
-    parser.add_argument('--csv-file-path', type=str,
+    parser.add_argument('--csv-file-path', type=str, default=None,
                         help='The path of the custom document corpus in CSV format. The CSV file should include '
                              'content, title, url, and description columns.')
     parser.add_argument('--embed-batch-size', type=int, default=64,

--- a/examples/run_storm_wiki_gpt_with_VectorRM.py
+++ b/examples/run_storm_wiki_gpt_with_VectorRM.py
@@ -34,7 +34,7 @@ sys.path.append('./')
 from knowledge_storm import STORMWikiRunnerArguments, STORMWikiRunner, STORMWikiLMConfigs
 from knowledge_storm.rm import VectorRM
 from knowledge_storm.lm import OpenAIModel, AzureOpenAIModel
-from knowledge_storm.utils import load_api_key, VectorStoreManager
+from knowledge_storm.utils import load_api_key, QdrantVectorStoreManager
 
 
 def main(args):
@@ -98,12 +98,12 @@ def main(args):
             'device': args.device,
         }
         if args.vector_db_mode == 'offline':
-            VectorStoreManager.create_or_update_vector_store(
+            QdrantVectorStoreManager.create_or_update_vector_store(
                 vector_store_path=args.offline_vector_db_dir,
                 **kwargs
             )
         elif args.vector_db_mode == 'online':
-            VectorStoreManager.create_or_update_vector_store(
+            QdrantVectorStoreManager.create_or_update_vector_store(
                 url=args.online_vector_db_url,
                 api_key=os.getenv('QDRANT_API_KEY'),
                 **kwargs

--- a/knowledge_storm/rm.py
+++ b/knowledge_storm/rm.py
@@ -177,8 +177,8 @@ class VectorRM(dspy.Retrieve):
     """
 
     def __init__(self,
-                 collection_name: str = "my_documents",
-                 embedding_model: str = 'BAAI/bge-m3',
+                 collection_name: str,
+                 embedding_model: str,
                  device: str = "mps",
                  k: int = 3,
                 ):
@@ -191,6 +191,12 @@ class VectorRM(dspy.Retrieve):
         """
         super().__init__(k=k)
         self.usage = 0
+        # check if the collection is provided
+        if not collection_name:
+            raise ValueError("Please provide a collection name.")
+        # check if the embedding model is provided
+        if not embedding_model:
+            raise ValueError("Please provide an embedding model.")
 
         model_kwargs = {"device": device}
         encode_kwargs = {"normalize_embeddings": True}

--- a/knowledge_storm/rm.py
+++ b/knowledge_storm/rm.py
@@ -5,11 +5,10 @@ from typing import Callable, Union, List
 import dspy
 import pandas as pd
 import requests
-from langchain_core.documents import Document
+
 from langchain_huggingface import HuggingFaceEmbeddings
 from langchain_qdrant import Qdrant
-from qdrant_client import QdrantClient, models
-from tqdm import tqdm
+from qdrant_client import QdrantClient
 
 from .utils import WebPageHelper
 
@@ -182,16 +181,13 @@ class VectorRM(dspy.Retrieve):
                  embedding_model: str = 'BAAI/bge-m3',
                  device: str = "mps",
                  k: int = 3,
-                 chunk_size: int = 500,
-                 chunk_overlap: int = 100):
+                ):
         """
         Params:
             collection_name: Name of the Qdrant collection.
             embedding_model: Name of the Hugging Face embedding model.
             device: Device to run the embeddings model on, can be "mps", "cuda", "cpu".
             k: Number of top chunks to retrieve.
-            chunk_size: Size of each chunk if you need to build the vector store from documents.
-            chunk_overlap: Overlap between chunks if you need to build the vector store from documents.
         """
         super().__init__(k=k)
         self.usage = 0
@@ -202,14 +198,11 @@ class VectorRM(dspy.Retrieve):
             model_name=embedding_model, model_kwargs=model_kwargs, encode_kwargs=encode_kwargs
         )
 
-        self.chunk_size = chunk_size
-        self.chunk_overlap = chunk_overlap
-
         self.collection_name = collection_name
         self.client = None
         self.qdrant = None
 
-    def _check_create_collection(self):
+    def _check_collection(self):
         """
         Check if the Qdrant collection exists and create it if it does not.
         """
@@ -223,17 +216,7 @@ class VectorRM(dspy.Retrieve):
                 embeddings=self.model,
             )
         else:
-            print(f"Collection {self.collection_name} does not exist. Creating the collection...")
-            # create the collection
-            self.client.create_collection(
-                collection_name=f"{self.collection_name}",
-                vectors_config=models.VectorParams(size=1024, distance=models.Distance.COSINE),
-            )
-            self.qdrant = Qdrant(
-                client=self.client,
-                collection_name=self.collection_name,
-                embeddings=self.model,
-            )
+            raise ValueError(f"Collection {self.collection_name} does not exist. Please create the collection first.")
 
     def init_online_vector_db(self, url: str, api_key: str):
         """
@@ -252,7 +235,7 @@ class VectorRM(dspy.Retrieve):
 
         try:
             self.client = QdrantClient(url=url, api_key=api_key)
-            self._check_create_collection()
+            self._check_collection()
         except Exception as e:
             raise ValueError(f"Error occurs when connecting to the server: {e}")
 
@@ -268,96 +251,9 @@ class VectorRM(dspy.Retrieve):
 
         try:
             self.client = QdrantClient(path=vector_store_path)
-            self._check_create_collection()
+            self._check_collection()
         except Exception as e:
             raise ValueError(f"Error occurs when loading the vector store: {e}")
-
-    def update_vector_store(
-            self,
-            file_path: str,
-            content_column: str,
-            title_column: str = "title",
-            url_column: str = "url",
-            desc_column: str = "description",
-            batch_size: int = 64
-    ):
-        """
-        Takes a CSV file where each row is a document and has columns for content, title, url, and description.
-        Then it converts all these documents in the content column to vectors and add them the Qdrant collection.
-
-        Args:
-            file_path (str): Path to the CSV file.
-            content_column (str): Name of the column containing the content.
-            title_column (str): Name of the column containing the title. Default is "title".
-            url_column (str): Name of the column containing the URL. Default is "url".
-            desc_column (str): Name of the column containing the description. Default is "description".
-            batch_size (int): Batch size for adding documents to the collection.
-        """
-        if file_path is None:
-            raise ValueError("Please provide a file path.")
-        # check if the file is a csv file
-        if not file_path.endswith('.csv'):
-            raise ValueError(f"Not valid file format. Please provide a csv file.")
-        if content_column is None:
-            raise ValueError("Please provide the name of the content column.")
-        if url_column is None:
-            raise ValueError("Please provide the name of the url column.")
-
-        if self.qdrant is None:
-            raise ValueError("Qdrant client is not initialized.")
-
-        # read the csv file
-        df = pd.read_csv(file_path)
-        # check that content column exists and url column exists
-        if content_column not in df.columns:
-            raise ValueError(f"Content column {content_column} not found in the csv file.")
-        if url_column not in df.columns:
-            raise ValueError(f"URL column {url_column} not found in the csv file.")
-
-        documents = [
-            Document(
-                page_content=row[content_column],
-                metadata={
-                    "title": row.get(title_column, ''),
-                    "url": row[url_column],
-                    "description": row.get(desc_column, ''),
-                }
-            )
-            for row in df.to_dict(orient='records')
-        ]
-
-        # split the documents
-        from langchain_text_splitters import RecursiveCharacterTextSplitter
-        text_splitter = RecursiveCharacterTextSplitter(
-            chunk_size=self.chunk_size,
-            chunk_overlap=self.chunk_overlap,
-            length_function=len,
-            add_start_index=True,
-            separators=[
-                "\n\n",
-                "\n",
-                ".",
-                "\uff0e",  # Fullwidth full stop
-                "\u3002",  # Ideographic full stop
-                ",",
-                "\uff0c",  # Fullwidth comma
-                "\u3001",  # Ideographic comma
-                " ",
-                "\u200B",  # Zero-width space
-                "",
-            ]
-        )
-        split_documents = text_splitter.split_documents(documents)
-
-        # update and save the vector store
-        num_batches = (len(split_documents) + batch_size - 1) // batch_size
-        for i in tqdm(range(num_batches)):
-            start_idx = i * batch_size
-            end_idx = min((i + 1) * batch_size, len(split_documents))
-            self.qdrant.add_documents(
-                documents=split_documents[start_idx:end_idx],
-                batch_size=batch_size,
-            )
 
     def get_usage_and_reset(self):
         usage = self.usage

--- a/knowledge_storm/utils.py
+++ b/knowledge_storm/utils.py
@@ -114,6 +114,7 @@ class QdrantVectorStoreManager:
     
     @staticmethod
     def create_or_update_vector_store(
+            collection_name: str,
             vector_db_mode: str,
             file_path: str,
             content_column: str,
@@ -123,7 +124,6 @@ class QdrantVectorStoreManager:
             batch_size: int = 64,
             chunk_size: int = 500,
             chunk_overlap: int = 100,
-            collection_name: str = "my_documents",
             vector_store_path: str = None,
             url: str =  None,
             qdrant_api_key: str = None,
@@ -150,7 +150,10 @@ class QdrantVectorStoreManager:
             device: Device to run the embeddings model on, can be "mps", "cuda", "cpu".
             qdrant_api_key: API key for the Qdrant server (Only required if the Qdrant server is online).
         """
-
+        # check if the collection name is provided
+        if collection_name is None:
+            raise ValueError("Please provide a collection name.")
+        
         model_kwargs = {"device": device}
         encode_kwargs = {"normalize_embeddings": True}
         model = HuggingFaceEmbeddings(

--- a/knowledge_storm/utils.py
+++ b/knowledge_storm/utils.py
@@ -40,6 +40,12 @@ def makeStringRed(message):
     return f"\033[91m {message}\033[00m"
 
 class QdrantVectorStoreManager:
+    """
+    This is a helper class to manage the Qdrant vector store. It is related to VectorRM retrieval model in rm.py.
+    It provides methods to create or update the vector store from a CSV file, before you initialize the VectorRM.
+    Use the function create_or_update_vector_store to create or update the vector store, then once you have the
+    vector store, you can initialize the VectorRM with the vector store path or the Qdrant server URL.
+    """
     @staticmethod
     def _check_create_collection(client: QdrantClient, collection_name: str, model: HuggingFaceEmbeddings):
         """

--- a/knowledge_storm/utils.py
+++ b/knowledge_storm/utils.py
@@ -72,6 +72,7 @@ class QdrantVectorStoreManager:
                 collection_name=collection_name,
                 embeddings=model,
             )
+    
     @staticmethod
     def _init_online_vector_db(url: str, api_key: str, collection_name: str, model: HuggingFaceEmbeddings):
         """
@@ -94,6 +95,7 @@ class QdrantVectorStoreManager:
         except Exception as e:
             raise ValueError(f"Error occurs when connecting to the server: {e}")
 
+    @staticmethod
     def _init_offline_vector_db(vector_store_path: str, collection_name: str, model: HuggingFaceEmbeddings):
         """
         Initialize the Qdrant client that is connected to an offline vector store with the given vector store folder path.
@@ -110,8 +112,8 @@ class QdrantVectorStoreManager:
         except Exception as e:
             raise ValueError(f"Error occurs when loading the vector store: {e}")
     
+    @staticmethod
     def create_or_update_vector_store(
-
             vector_db_mode: str,
             file_path: str,
             content_column: str,

--- a/knowledge_storm/utils.py
+++ b/knowledge_storm/utils.py
@@ -10,7 +10,13 @@ from typing import List, Dict
 import httpx
 import toml
 from langchain_text_splitters import RecursiveCharacterTextSplitter
+from langchain_core.documents import Document
+from langchain_huggingface import HuggingFaceEmbeddings
+from langchain_qdrant import Qdrant
+from qdrant_client import QdrantClient, models
 from trafilatura import extract
+from tqdm import tqdm
+import pandas as pd
 
 logging.getLogger("httpx").setLevel(logging.WARNING)  # Disable INFO logging for httpx.
 
@@ -32,6 +38,198 @@ def load_api_key(toml_file_path):
 
 def makeStringRed(message):
     return f"\033[91m {message}\033[00m"
+
+class VectorStoreManager:
+    @staticmethod
+    def _check_create_collection(client: QdrantClient, collection_name: str, model: HuggingFaceEmbeddings):
+        """
+        Check if the Qdrant collection exists and create it if it does not.
+        """
+        if client is None:
+            raise ValueError("Qdrant client is not initialized.")
+        if client.collection_exists(collection_name=f"{collection_name}"):
+            print(f"Collection {collection_name} exists. Loading the collection...")
+            return Qdrant(
+                client=client,
+                collection_name=collection_name,
+                embeddings=model,
+            )
+        else:
+            print(f"Collection {collection_name} does not exist. Creating the collection...")
+            # create the collection
+            client.create_collection(
+                collection_name=f"{collection_name}",
+                vectors_config=models.VectorParams(size=1024, distance=models.Distance.COSINE),
+            )
+            return Qdrant(
+                client=client,
+                collection_name=collection_name,
+                embeddings=model,
+            )
+    @staticmethod
+    def _init_online_vector_db(url: str, api_key: str, collection_name: str, model: HuggingFaceEmbeddings):
+        """
+        Initialize the Qdrant client that is connected to an online vector store with the given URL and API key.
+
+        Args:
+            url (str): URL of the Qdrant server.
+            api_key (str): API key for the Qdrant server.
+        """
+        if api_key is None:
+            if not os.getenv("QDRANT_API_KEY"):
+                raise ValueError("Please provide an api key.")
+            api_key = os.getenv("QDRANT_API_KEY")
+        if url is None:
+            raise ValueError("Please provide a url for the Qdrant server.")
+
+        try:
+            client = QdrantClient(url=url, api_key=api_key)
+            return VectorStoreManager._check_create_collection(client=client, collection_name=collection_name, model=model)
+        except Exception as e:
+            raise ValueError(f"Error occurs when connecting to the server: {e}")
+
+    def _init_offline_vector_db(vector_store_path: str, collection_name: str, model: HuggingFaceEmbeddings):
+        """
+        Initialize the Qdrant client that is connected to an offline vector store with the given vector store folder path.
+
+        Args:
+            vector_store_path (str): Path to the vector store.
+        """
+        if vector_store_path is None:
+            raise ValueError("Please provide a folder path.")
+
+        try:
+            client = QdrantClient(path=vector_store_path)
+            return VectorStoreManager._check_create_collection(client=client, collection_name=collection_name, model=model)
+        except Exception as e:
+            raise ValueError(f"Error occurs when loading the vector store: {e}")
+    
+    def create_or_update_vector_store(
+
+            vector_db_mode: str,
+            file_path: str,
+            content_column: str,
+            title_column: str = "title",
+            url_column: str = "url",
+            desc_column: str = "description",
+            batch_size: int = 64,
+            chunk_size: int = 500,
+            chunk_overlap: int = 100,
+            collection_name: str = "my_documents",
+            vector_store_path: str = None,
+            url: str =  None,
+            qdrant_api_key: str = None,
+            embedding_model: str = 'BAAI/bge-m3',
+            device: str = "mps",
+    ):
+        """
+        Takes a CSV file where each row is a document and has columns for content, title, url, and description.
+        Then it converts all these documents in the content column to vectors and add them the Qdrant collection.
+
+        Args:
+            vector_store_path (str): Path to the directory where the vector store is stored or will be stored. 
+            vector_db_mode (str): Mode of the Qdrant vector store (offline or online).
+            file_path (str): Path to the CSV file.
+            content_column (str): Name of the column containing the content.
+            title_column (str): Name of the column containing the title. Default is "title".
+            url_column (str): Name of the column containing the URL. Default is "url".
+            desc_column (str): Name of the column containing the description. Default is "description".
+            batch_size (int): Batch size for adding documents to the collection.
+            chunk_size: Size of each chunk if you need to build the vector store from documents.
+            chunk_overlap: Overlap between chunks if you need to build the vector store from documents.
+            collection_name: Name of the Qdrant collection.
+            embedding_model: Name of the Hugging Face embedding model.
+            device: Device to run the embeddings model on, can be "mps", "cuda", "cpu".
+            qdrant_api_key: API key for the Qdrant server (Only required if the Qdrant server is online).
+        """
+
+        model_kwargs = {"device": device}
+        encode_kwargs = {"normalize_embeddings": True}
+        model = HuggingFaceEmbeddings(
+            model_name=embedding_model, model_kwargs=model_kwargs, encode_kwargs=encode_kwargs
+        )
+
+        if file_path is None:
+            raise ValueError("Please provide a file path.")
+        # check if the file is a csv file
+        if not file_path.endswith('.csv'):
+            raise ValueError(f"Not valid file format. Please provide a csv file.")
+        if content_column is None:
+            raise ValueError("Please provide the name of the content column.")
+        if url_column is None:
+            raise ValueError("Please provide the name of the url column.")
+
+        # try to initialize the Qdrant client
+        qdrant = None
+        if vector_db_mode == 'online':
+            qdrant = VectorStoreManager._init_online_vector_db(
+                url=url,
+                api_key=qdrant_api_key,
+                collection_name=collection_name,
+                model=model,
+            )
+        elif vector_db_mode == 'offline':
+            qdrant = VectorStoreManager._init_offline_vector_db(vector_store_path=vector_store_path, collection_name=collection_name, model=model)
+        else:
+            raise ValueError("Invalid vector_db_mode. Please provide either 'online' or 'offline'.")
+        if qdrant is None:
+            raise ValueError("Qdrant client is not initialized.")
+
+        # read the csv file
+        df = pd.read_csv(file_path)
+        # check that content column exists and url column exists
+        if content_column not in df.columns:
+            raise ValueError(f"Content column {content_column} not found in the csv file.")
+        if url_column not in df.columns:
+            raise ValueError(f"URL column {url_column} not found in the csv file.")
+
+        documents = [
+            Document(
+                page_content=row[content_column],
+                metadata={
+                    "title": row.get(title_column, ''),
+                    "url": row[url_column],
+                    "description": row.get(desc_column, ''),
+                }
+            )
+            for row in df.to_dict(orient='records')
+        ]
+
+        # split the documents
+        from langchain_text_splitters import RecursiveCharacterTextSplitter
+        text_splitter = RecursiveCharacterTextSplitter(
+            chunk_size=chunk_size,
+            chunk_overlap=chunk_overlap,
+            length_function=len,
+            add_start_index=True,
+            separators=[
+                "\n\n",
+                "\n",
+                ".",
+                "\uff0e",  # Fullwidth full stop
+                "\u3002",  # Ideographic full stop
+                ",",
+                "\uff0c",  # Fullwidth comma
+                "\u3001",  # Ideographic comma
+                " ",
+                "\u200B",  # Zero-width space
+                "",
+            ]
+        )
+        split_documents = text_splitter.split_documents(documents)
+
+        # update and save the vector store
+        num_batches = (len(split_documents) + batch_size - 1) // batch_size
+        for i in tqdm(range(num_batches)):
+            start_idx = i * batch_size
+            end_idx = min((i + 1) * batch_size, len(split_documents))
+            qdrant.add_documents(
+                documents=split_documents[start_idx:end_idx],
+                batch_size=batch_size,
+            )
+        
+        # close the qdrant client
+        qdrant.client.close()
 
 
 class ArticleTextProcessing:

--- a/knowledge_storm/utils.py
+++ b/knowledge_storm/utils.py
@@ -39,7 +39,7 @@ def load_api_key(toml_file_path):
 def makeStringRed(message):
     return f"\033[91m {message}\033[00m"
 
-class VectorStoreManager:
+class QdrantVectorStoreManager:
     @staticmethod
     def _check_create_collection(client: QdrantClient, collection_name: str, model: HuggingFaceEmbeddings):
         """
@@ -84,7 +84,7 @@ class VectorStoreManager:
 
         try:
             client = QdrantClient(url=url, api_key=api_key)
-            return VectorStoreManager._check_create_collection(client=client, collection_name=collection_name, model=model)
+            return QdrantVectorStoreManager._check_create_collection(client=client, collection_name=collection_name, model=model)
         except Exception as e:
             raise ValueError(f"Error occurs when connecting to the server: {e}")
 
@@ -100,7 +100,7 @@ class VectorStoreManager:
 
         try:
             client = QdrantClient(path=vector_store_path)
-            return VectorStoreManager._check_create_collection(client=client, collection_name=collection_name, model=model)
+            return QdrantVectorStoreManager._check_create_collection(client=client, collection_name=collection_name, model=model)
         except Exception as e:
             raise ValueError(f"Error occurs when loading the vector store: {e}")
     
@@ -162,14 +162,14 @@ class VectorStoreManager:
         # try to initialize the Qdrant client
         qdrant = None
         if vector_db_mode == 'online':
-            qdrant = VectorStoreManager._init_online_vector_db(
+            qdrant = QdrantVectorStoreManager._init_online_vector_db(
                 url=url,
                 api_key=qdrant_api_key,
                 collection_name=collection_name,
                 model=model,
             )
         elif vector_db_mode == 'offline':
-            qdrant = VectorStoreManager._init_offline_vector_db(vector_store_path=vector_store_path, collection_name=collection_name, model=model)
+            qdrant = QdrantVectorStoreManager._init_offline_vector_db(vector_store_path=vector_store_path, collection_name=collection_name, model=model)
         else:
             raise ValueError("Invalid vector_db_mode. Please provide either 'online' or 'offline'.")
         if qdrant is None:


### PR DESCRIPTION
now users can just create or update vector stores with adding a csv file path without the need for update-vector-store. so this clears confusion. 
Also, moved the function that creates and updates the vector stores to utils.py to leave VectorRM only as a retriever. 

I also updated the example python script to reflect the changes.