### PR TITLE
[RM Enhancement] Fixed SerperRM when knowledge graph is none to properly return data

### DIFF
--- a/knowledge_storm/rm.py
+++ b/knowledge_storm/rm.py
@@ -432,8 +432,8 @@ class SerperRM(dspy.Retrieve):
                         collected_results.append(
                             {
                                 'snippets': snippets,
-                                'title': result.get('title'),
-                                'url': result.get('link'),
+                                'title': organic.get('title'),
+                                'url': organic.get('link'),
                                 'description': '',
                             }
                         )


### PR DESCRIPTION
This PR aims to accomplish the following:
- Update the SerperRM collected_results to utilize organic to grab the title + link opposed to result.

This has been reported in #131 

Thank you.