### PR TITLE
Use `black` as the python code formatter.

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -40,4 +40,9 @@ Following the suggested format can lead to a faster review process.
 
 **Code Format:**
 
-We adopt [PEP8 rules](https://peps.python.org/pep-0008/) for arranging and formatting Python code. Please use a code formatter tool in your IDE to reformat the code before submitting the PR.
+We adopt [`black`](https://github.com/psf/black) for arranging and formatting Python code. Please complete the following step before submitting the PR. See [here](https://github.com/psf/black?tab=readme-ov-file#installation-and-usage) for more information.
+```shell
+pip install black
+black {path_to_the_changed_python_code}
+```
+

--- a/README.md
+++ b/README.md
@@ -17,6 +17,8 @@
 - [2024/05] We add Bing Search support in [rm.py](knowledge_storm/rm.py). Test STORM with `GPT-4o` - we now configure the article generation part in our demo using `GPT-4o` model.
 - [2024/04] We release refactored version of STORM codebase! We define [interface](knowledge_storm/interface.py) for STORM pipeline and reimplement STORM-wiki (check out [`src/storm_wiki`](knowledge_storm/storm_wiki)) to demonstrate how to instantiate the pipeline. We provide API to support customization of different language models and retrieval/search integration.
 
+[![Code style: black](https://img.shields.io/badge/code%20style-black-000000.svg)](https://github.com/psf/black)
+
 ## Overview [(Try STORM now!)](https://storm.genie.stanford.edu/)
 
 <p align="center">


### PR DESCRIPTION
Use `black` as the python code formatter to maintain the code quality. Reformat `knowledge_storm/**`.