### PR TITLE
Fixing Typo "reogranize" -> "reorganize"

### DIFF
--- a/README.md
+++ b/README.md
@@ -208,7 +208,7 @@ conv_turn = costorm_runner.step()
 costorm_runner.step(user_utterance="YOUR UTTERANCE HERE")
 
 # Generate report based on the collaborative discourse
-costorm_runner.knowledge_base.reogranize()
+costorm_runner.knowledge_base.reorganize()
 article = costorm_runner.generate_report()
 print(article)
 ```

--- a/examples/costorm_examples/run_costorm_gpt.py
+++ b/examples/costorm_examples/run_costorm_gpt.py
@@ -133,7 +133,7 @@ def main(args):
     print(f"**{conv_turn.role}**: {conv_turn.utterance}\n")
 
     # generate report
-    costorm_runner.knowledge_base.reogranize()
+    costorm_runner.knowledge_base.reorganize()
     article = costorm_runner.generate_report()
 
     # save results

--- a/knowledge_storm/collaborative_storm/engine.py
+++ b/knowledge_storm/collaborative_storm/engine.py
@@ -607,7 +607,7 @@ class CoStormRunner:
                     warmstart_revised_conv if warmstart_revised_conv else warmstart_conv
                 )
                 self.warmstart_conv_archive = warmstart_conv
-                self.knowledge_base.reogranize()
+                self.knowledge_base.reorganize()
             else:
                 if self.knowledge_base is None:
                     self.knowledge_base = KnowledgeBase(
@@ -741,5 +741,5 @@ class CoStormRunner:
                     ):
                         if self.callback_handler is not None:
                             self.callback_handler.on_mindmap_reorg_start()
-                        self.knowledge_base.reogranize()
+                        self.knowledge_base.reorganize()
         return conv_turn

--- a/knowledge_storm/dataclass.py
+++ b/knowledge_storm/dataclass.py
@@ -825,7 +825,7 @@ class KnowledgeBase:
     def get_knowledge_base_summary(self):
         return self.gen_summary_module(self)
 
-    def reogranize(self):
+    def reorganize(self):
         """
         Reorganizes the knowledge base through two main processes: top-down expansion and bottom-up cleaning.
 


### PR DESCRIPTION
This pull request corrects a typo from "reogranize" to "reorganize."

Although this change might cause issues for applications depending on this repository, given that the project is still in its early stages, now is an ideal time to address these small but important cleanups to ensure a more robust foundation going forward.