### PR TITLE
[SerperRM Bug]

### DIFF
--- a/knowledge_storm/rm.py
+++ b/knowledge_storm/rm.py
@@ -537,7 +537,7 @@ class SerperRM(dspy.Retrieve):
                     snippets = [organic.get("snippet")]
                     if self.ENABLE_EXTRA_SNIPPET_EXTRACTION:
                         snippets.extend(
-                            valid_url_to_snippets.get(url, {}).get("snippets", [])
+                            valid_url_to_snippets.get(url.strip("\'"), {}).get("snippets", [])
                         )
                     collected_results.append(
                         {

--- a/knowledge_storm/rm.py
+++ b/knowledge_storm/rm.py
@@ -537,7 +537,9 @@ class SerperRM(dspy.Retrieve):
                     snippets = [organic.get("snippet")]
                     if self.ENABLE_EXTRA_SNIPPET_EXTRACTION:
                         snippets.extend(
-                            valid_url_to_snippets.get(url.strip("\'"), {}).get("snippets", [])
+                            valid_url_to_snippets.get(url.strip("'"), {}).get(
+                                "snippets", []
+                            )
                         )
                     collected_results.append(
                         {


### PR DESCRIPTION
valid_url_to_snippets.get(url, {}) get none value. call strip function will be fix it. just like url.strip("\'")