### PR TITLE
Set azure_api_key as optional parameter

### DIFF
--- a/knowledge_storm/storm_wiki/engine.py
+++ b/knowledge_storm/storm_wiki/engine.py
@@ -38,8 +38,8 @@ class STORMWikiLMConfigs(LMConfigs):
     def init_openai_model(
         self,
         openai_api_key: str,
-        azure_api_key: str,
         openai_type: Literal["openai", "azure"],
+        azure_api_key: Optional[str] = None,
         api_base: Optional[str] = None,
         api_version: Optional[str] = None,
         temperature: Optional[float] = 1.0,


### PR DESCRIPTION
This pull request modifies the azure_api_key function to make its parameter optional.

The change ensures flexibility when calling the function, particularly for cases where the API key may not always be required.

Key Changes:
- Made the azure_api_key parameter optional in the knowledge_storm/storm_wiki/engine.py init_openai_model definition.