### PR TITLE
Add PGVector retriever support

### DIFF
--- a/examples/storm_examples/run_storm_wiki_gemini.py
+++ b/examples/storm_examples/run_storm_wiki_gemini.py
@@ -2,7 +2,7 @@
 STORM Wiki pipeline powered by Google Gemini models and search engine.
 You need to set up the following environment variables to run this script:
     - GOOGLE_API_KEY: Google API key (Can be obtained from https://ai.google.dev/gemini-api/docs/api-key)
-    - YDC_API_KEY: You.com API key; BING_SEARCH_API_KEY: Bing Search API key, SERPER_API_KEY: Serper API key, BRAVE_API_KEY: Brave API key, or TAVILY_API_KEY: Tavily API key
+    - YDC_API_KEY: You.com API key; BING_SEARCH_API_KEY: Bing Search API key, SERPER_API_KEY: Serper API key, BRAVE_API_KEY: Brave API key, TAVILY_API_KEY: Tavily API key, PGVECTOR_DB_URL: PGVector database URL, GRAPH_RAG_DATA: GraphRAG data in JSON format
 
 Output will be structured as below
 args.output_dir/
@@ -21,7 +21,7 @@ from argparse import ArgumentParser
 
 from knowledge_storm import STORMWikiRunnerArguments, STORMWikiRunner, STORMWikiLMConfigs
 from knowledge_storm.lm import GoogleModel
-from knowledge_storm.rm import YouRM, BingSearch, BraveRM, SerperRM, DuckDuckGoSearchRM, TavilySearchRM, SearXNG
+from knowledge_storm.rm import YouRM, BingSearch, BraveRM, SerperRM, DuckDuckGoSearchRM, TavilySearchRM, SearXNG, PGVectorRM, GraphRAGRM
 from knowledge_storm.utils import load_api_key
 
 def main(args):
@@ -77,8 +77,12 @@ def main(args):
             rm = TavilySearchRM(tavily_search_api_key=os.getenv('TAVILY_API_KEY'), k=engine_args.search_top_k, include_raw_content=True)
         case 'searxng':
             rm = SearXNG(searxng_api_key=os.getenv('SEARXNG_API_KEY'), k=engine_args.search_top_k)
+        case 'pgvector':
+            rm = PGVectorRM(db_url=os.getenv('PGVECTOR_DB_URL'), table_name='documents', embedding_model='BAAI/bge-m3', k=engine_args.search_top_k)
+        case 'graphrag':
+            rm = GraphRAGRM(graph_data=os.getenv('GRAPH_RAG_DATA'), embedding_model='BAAI/bge-m3', k=engine_args.search_top_k)
         case _:
-             raise ValueError(f'Invalid retriever: {args.retriever}. Choose either "bing", "you", "brave", "duckduckgo", "serper", "tavily", or "searxng"')
+             raise ValueError(f'Invalid retriever: {args.retriever}. Choose either "bing", "you", "brave", "duckduckgo", "serper", "tavily", "searxng", "pgvector", or "graphrag"')
 
     runner = STORMWikiRunner(engine_args, lm_configs, rm)
 
@@ -103,7 +107,7 @@ if __name__ == '__main__':
                         help='Maximum number of threads to use. The information seeking part and the article generation'
                              'part can speed up by using multiple threads. Consider reducing it if keep getting '
                              '"Exceed rate limit" error when calling LM API.')
-    parser.add_argument('--retriever', type=str, choices=['bing', 'you', 'brave', 'serper', 'duckduckgo', 'tavily', 'searxng'],
+    parser.add_argument('--retriever', type=str, choices=['bing', 'you', 'brave', 'serper', 'duckduckgo', 'tavily', 'searxng', 'pgvector', 'graphrag'],
                         help='The search engine API to use for retrieving information.')
     # stage of the pipeline
     parser.add_argument('--do-research', action='store_true',

--- a/knowledge_storm/collaborative_storm/engine.py
+++ b/knowledge_storm/collaborative_storm/engine.py
@@ -17,7 +17,7 @@ from ..dataclass import ConversationTurn, KnowledgeBase
 from ..interface import LMConfigs, Agent
 from ..logging_wrapper import LoggingWrapper
 from ..lm import OpenAIModel, AzureOpenAIModel, TogetherClient
-from ..rm import BingSearch
+from ..rm import BingSearch, PGVectorRetriever
 
 
 class CollaborativeStormLMConfigs(LMConfigs):
@@ -35,6 +35,7 @@ class CollaborativeStormLMConfigs(LMConfigs):
         self.warmstart_outline_gen_lm = None
         self.question_asking_lm = None
         self.knowledge_base_lm = None
+        self.pgvector_retriever = None  # Peebb
 
     def init(
         self,
@@ -158,6 +159,9 @@ class CollaborativeStormLMConfigs(LMConfigs):
 
     def set_knowledge_base_lm(self, model: Union[dspy.dsp.LM, dspy.dsp.HFModel]):
         self.knowledge_base_lm = model
+
+    def set_pgvector_retriever(self, retriever: PGVectorRetriever):  # Peebb
+        self.pgvector_retriever = retriever  # Peebb
 
     def collect_and_reset_lm_usage(self):
         lm_usage = {}

--- a/tests/test_pgvector_retriever.py
+++ b/tests/test_pgvector_retriever.py
@@ -1,0 +1,44 @@
+import unittest
+from unittest.mock import patch, MagicMock
+from knowledge_storm.rm import PGVectorRetriever
+
+class TestPGVectorRetriever(unittest.TestCase):
+
+    @patch('knowledge_storm.rm.create_engine')
+    @patch('knowledge_storm.rm.HuggingFaceEmbeddings')
+    def setUp(self, MockHuggingFaceEmbeddings, MockCreateEngine):
+        self.mock_model = MockHuggingFaceEmbeddings.return_value
+        self.mock_engine = MockCreateEngine.return_value
+        self.retriever = PGVectorRetriever(
+            db_url='postgresql://user:password@localhost/dbname',
+            table_name='documents',
+            embedding_model='BAAI/bge-m3',
+            k=3
+        )
+
+    @patch('knowledge_storm.rm.PGVectorRetriever.Session')
+    def test_forward(self, MockSession):
+        mock_session = MockSession.return_value
+        mock_query = MagicMock()
+        mock_session.query.return_value.order_by.return_value.limit.return_value.all.return_value = [
+            MagicMock(description='desc1', content='content1', title='title1', url='url1'),
+            MagicMock(description='desc2', content='content2', title='title2', url='url2')
+        ]
+        self.retriever.model.embed_query.return_value = [0.1, 0.2, 0.3]
+
+        results = self.retriever.forward('test query', [])
+
+        self.assertEqual(len(results), 2)
+        self.assertEqual(results[0]['description'], 'desc1')
+        self.assertEqual(results[0]['snippets'], ['content1'])
+        self.assertEqual(results[0]['title'], 'title1')
+        self.assertEqual(results[0]['url'], 'url1')
+
+    def test_get_usage_and_reset(self):
+        self.retriever.usage = 5
+        usage = self.retriever.get_usage_and_reset()
+        self.assertEqual(usage, {'PGVectorRetriever': 5})
+        self.assertEqual(self.retriever.usage, 0)
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
Related to #167

Add support for PGVector and GraphRAG retrievals.

* **knowledge_storm/rm.py**:
  - Add `PGVectorRetriever` class to support PGVector retrieval.
  - Add `GraphRAGRM` class to support GraphRAG retrieval.
  - Update import statements to include necessary libraries for PGVector and GraphRAG.

* **examples/storm_examples/run_storm_wiki_claude.py** and **examples/storm_examples/run_storm_wiki_gemini.py**:
  - Update environment variable descriptions to include PGVector and GraphRAG.
  - Add cases for `pgvector` and `graphrag` retrievers in the main function.

* **knowledge_storm/collaborative_storm/engine.py**:
  - Add `pgvector_retriever` attribute to `CollaborativeStormLMConfigs` class.
  - Add `set_pgvector_retriever` method to `CollaborativeStormLMConfigs` class.
  - Update import statements to include `PGVectorRetriever`.

* **tests/test_pgvector_retriever.py**:
  - Add unit tests for the new `PGVectorRetriever` class.

