### PR TITLE
Fix(knowledge_curation.py): Remove duplicate self.retriever assignmen…

### DIFF
--- a/knowledge_storm/storm_wiki/modules/knowledge_curation.py
+++ b/knowledge_storm/storm_wiki/modules/knowledge_curation.py
@@ -268,7 +268,6 @@ class StormKnowledgeCurationModule(KnowledgeCurationModule):
         self.conv_simulator_lm = conv_simulator_lm
         self.search_top_k = search_top_k
         self.max_thread_num = max_thread_num
-        self.retriever = retriever
         self.conv_simulator = ConvSimulator(
             topic_expert_engine=conv_simulator_lm,
             question_asker_engine=question_asker_lm,


### PR DESCRIPTION
This pull request addresses a minor bug in the `StormKnowledgeCurationModule` class within the `knowledge_curation.py` file. The `self.retriever` attribute was being assigned twice within the `__init__` method.

**Impact of the change:**

Removing the duplicate assignment simplifies the code, improves readability, and reduces the potential for confusion or subtle errors in the future. It ensures that `self.retriever` is initialized only once, as intended.