### PR TITLE
Typo fix in example groq script run_storm_wiki_groq.py

### DIFF
--- a/examples/storm_examples/run_storm_wiki_groq.py
+++ b/examples/storm_examples/run_storm_wiki_groq.py
@@ -24,8 +24,8 @@ from argparse import ArgumentParser
 from knowledge_storm import STORMWikiRunnerArguments, STORMWikiRunner, STORMWikiLMConfigs
 
 # Now import lm directly
-import lm
-from lm import GroqModel
+
+from knowledge_storm.lm import GroqModel
 from knowledge_storm.rm import YouRM, BingSearch, BraveRM, SerperRM, DuckDuckGoSearchRM, TavilySearchRM, SearXNG
 from knowledge_storm.utils import load_api_key
 


### PR DESCRIPTION
There is a typo fix in `examples/storm_examples/run_storm_wiki_groq.py`file. 

The changes I made are inline with the other storm_examples files such as `examples/storm_examples/run_storm_wiki_mistral.py` which can be seen in the link below

https://github.com/stanford-oval/storm/blob/39a21e6cee42c1e77011f169a00fae0822033c57/examples/storm_examples/run_storm_wiki_mistral.py#L24C1-L25C1
