### PR TITLE
[Fix] Spelling error in "reogranize" and [Feat] Minor improvements to `Encoder` and `CoStormRunner`

### DIFF
--- a/knowledge_storm/collaborative_storm/engine.py
+++ b/knowledge_storm/collaborative_storm/engine.py
@@ -618,7 +618,7 @@ class CoStormRunner:
                     warmstart_revised_conv if warmstart_revised_conv else warmstart_conv
                 )
                 self.warmstart_conv_archive = warmstart_conv
-                self.knowledge_base.reogranize()
+                self.knowledge_base.reorganize()
             else:
                 if self.knowledge_base is None:
                     self.knowledge_base = KnowledgeBase(
@@ -757,5 +757,5 @@ class CoStormRunner:
                     ):
                         if self.callback_handler is not None:
                             self.callback_handler.on_mindmap_reorg_start()
-                        self.knowledge_base.reogranize()
+                        self.knowledge_base.reorganize()
         return conv_turn

--- a/knowledge_storm/collaborative_storm/engine.py
+++ b/knowledge_storm/collaborative_storm/engine.py
@@ -509,6 +509,7 @@ class CoStormRunner:
         runner_argument: RunnerArgument,
         logging_wrapper: LoggingWrapper,
         rm: Optional[dspy.Retrieve] = None,
+        encoder: Optional[Encoder] = None,
         callback_handler: BaseCallbackHandler = None,
     ):
         self.runner_argument = runner_argument
@@ -519,7 +520,10 @@ class CoStormRunner:
             self.rm = BingSearch(k=runner_argument.retrieve_top_k)
         else:
             self.rm = rm
-        self.encoder = Encoder()
+        if encoder is None:
+            self.encoder = Encoder()
+        else:
+            self.encoder = encoder
         self.conversation_history = []
         self.warmstart_conv_archive = []
         self.knowledge_base = KnowledgeBase(

--- a/knowledge_storm/dataclass.py
+++ b/knowledge_storm/dataclass.py
@@ -825,7 +825,7 @@ class KnowledgeBase:
     def get_knowledge_base_summary(self):
         return self.gen_summary_module(self)
 
-    def reogranize(self):
+    def reorganize(self):
         """
         Reorganizes the knowledge base through two main processes: top-down expansion and bottom-up cleaning.
 

--- a/knowledge_storm/encoder.py
+++ b/knowledge_storm/encoder.py
@@ -60,6 +60,7 @@ class Encoder:
         api_key: Optional[str] = None,
         api_base: Optional[str] = None,
         api_version: Optional[str] = None,
+        extra_headers: Optional[Dict[str, str]] = None,
     ):
         """
         Initializes the Encoder with the appropriate embedding model.
@@ -69,6 +70,7 @@ class Encoder:
             api_key (Optional[str]): API key for the encoder service.
             api_base (Optional[str]): API base URL for the encoder service.
             api_version (Optional[str]): API version for the encoder service.
+            extra_headers (Optional[Dict[str, str]]): Additional headers for the encoder service.
         """
         self.embedding_model_name = None
         self.kargs = {}
@@ -88,6 +90,7 @@ class Encoder:
                 "api_key": api_key or os.getenv("AZURE_API_KEY"),
                 "api_base": api_base or os.getenv("AZURE_API_BASE"),
                 "api_version": api_version or os.getenv("AZURE_API_VERSION"),
+                "extra_headers": extra_headers,
             }
         else:
             raise ValueError(


### PR DESCRIPTION
This PR has a two small improvements and fixes a spelling error. 

### Spelling error

  - Corrected the misspelled method name from `reogranize` to `reorganize` in both the `collaborative_storm/engine.py` and `dataclass.py` files.

### Optional Encoder Injection in CoStormRunner

  - Updated the `CoStormRunner` initialization to make encoder injection optional. If no encoder is provided, a default `Encoder` instance is automatically created (matching current behavior).

### Support for Extra Headers in Encoder Initialization

  - Added support for passing `extra_headers` during the initialization of the `Encoder` class. This allows for additional header configurations when using azure embedding models.