### PR TITLE
Fix issues with Google Search: empty queries and timeouts

### DIFF
--- a/knowledge_storm/rm.py
+++ b/knowledge_storm/rm.py
@@ -1067,6 +1067,9 @@ class GoogleSearch(dspy.Retrieve):
         url_to_results = {}
 
         for query in queries:
+            if not query or query.isspace():
+                logging.warning(f"Skipping empty or whitespace query.")
+                continue # Skip this iteration if query is invalid
             try:
                 response = (
                     self.service.cse()

--- a/knowledge_storm/utils.py
+++ b/knowledge_storm/utils.py
@@ -673,7 +673,7 @@ class WebPageHelper:
 
     def download_webpage(self, url: str):
         try:
-            res = self.httpx_client.get(url, timeout=4)
+            res = self.httpx_client.get(url, timeout=12)
             if res.status_code >= 400:
                 res.raise_for_status()
             return res.content


### PR DESCRIPTION
I ran into issues when using GoogleSearch. Logs show attempts to search with empty query string. In other cases, there were timeout errors with 4s limit.