### PR TITLE
[nit] loose requirements version restriction

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,0 +1,3 @@
+include requirements.txt
+include LICENSE
+include README.md

--- a/requirements.txt
+++ b/requirements.txt
@@ -7,6 +7,6 @@ trafilatura
 langchain-huggingface
 qdrant-client
 langchain-qdrant
-numpy==1.26.4
-litellm==1.59.3
+numpy
+litellm
 diskcache

--- a/setup.py
+++ b/setup.py
@@ -16,7 +16,7 @@ with open("requirements.txt", encoding="utf-8") as f:
 
 setup(
     name="knowledge-storm",
-    version="1.1.0",
+    version="1.1.1",
     author="Yijia Shao, Yucheng Jiang",
     author_email="shaoyj@stanford.edu, yuchengj@stanford.edu",
     description="STORM: A language model-powered knowledge curation engine.",


### PR DESCRIPTION
Loose the version restriction on `numpy` and `litellm` to resolve conflict between `knowledge_storm` and other packages.