### PR TITLE
Add MiniMax LLM provider support (M3 default)

### DIFF
--- a/README.md
+++ b/README.md
@@ -233,9 +233,11 @@ OPENAI_API_TYPE="openai"
 OPENAI_API_TYPE="azure"
 AZURE_API_BASE="your_azure_api_base_url"
 AZURE_API_VERSION="your_azure_api_version"
-# ============ retriever configurations ============ 
+# Set up MiniMax API key (https://www.minimaxi.com/).
+MINIMAX_API_KEY="your_minimax_api_key"
+# ============ retriever configurations ============
 BING_SEARCH_API_KEY="your_bing_search_api_key" # if using bing search
-# ============ encoder configurations ============ 
+# ============ encoder configurations ============
 ENCODER_API_TYPE="openai" # if using openai encoder
 ```
 
@@ -253,6 +255,20 @@ python examples/storm_examples/run_storm_wiki_gpt.py \
     --do-generate-article \
     --do-polish-article
 ```
+
+**To run STORM with [MiniMax](https://www.minimaxi.com/) models:**
+
+```bash
+python examples/storm_examples/run_storm_wiki_minimax.py \
+    --output-dir $OUTPUT_DIR \
+    --retriever you \
+    --do-research \
+    --do-generate-outline \
+    --do-generate-article \
+    --do-polish-article
+```
+
+MiniMax offers `MiniMax-M2.5` and `MiniMax-M2.5-highspeed` models with a 204K context window. Use `--model MiniMax-M2.5-highspeed` for faster inference.
 
 **To run STORM using your favorite language models or grounding on your own corpus:** Check out [examples/storm_examples/README.md](examples/storm_examples/README.md).
 

--- a/README.md
+++ b/README.md
@@ -268,7 +268,7 @@ python examples/storm_examples/run_storm_wiki_minimax.py \
     --do-polish-article
 ```
 
-MiniMax offers `MiniMax-M2.7` (latest flagship), `MiniMax-M2.7-highspeed`, `MiniMax-M2.5`, and `MiniMax-M2.5-highspeed` models with a 204K context window. The default model is `MiniMax-M2.7`. Use `--model MiniMax-M2.7-highspeed` for faster inference.
+MiniMax offers `MiniMax-M3` (latest flagship, default), `MiniMax-M2.7`, and `MiniMax-M2.7-highspeed` models. `MiniMax-M3` provides a 512K context window, up to 128K max output, and image input support. The default model is `MiniMax-M3`. Use `--model MiniMax-M2.7-highspeed` for faster inference.
 
 **To run STORM using your favorite language models or grounding on your own corpus:** Check out [examples/storm_examples/README.md](examples/storm_examples/README.md).
 

--- a/README.md
+++ b/README.md
@@ -268,7 +268,7 @@ python examples/storm_examples/run_storm_wiki_minimax.py \
     --do-polish-article
 ```
 
-MiniMax offers `MiniMax-M2.5` and `MiniMax-M2.5-highspeed` models with a 204K context window. Use `--model MiniMax-M2.5-highspeed` for faster inference.
+MiniMax offers `MiniMax-M2.7` (latest flagship), `MiniMax-M2.7-highspeed`, `MiniMax-M2.5`, and `MiniMax-M2.5-highspeed` models with a 204K context window. The default model is `MiniMax-M2.7`. Use `--model MiniMax-M2.7-highspeed` for faster inference.
 
 **To run STORM using your favorite language models or grounding on your own corpus:** Check out [examples/storm_examples/README.md](examples/storm_examples/README.md).
 

--- a/examples/storm_examples/README.md
+++ b/examples/storm_examples/README.md
@@ -3,7 +3,7 @@
 We host a number of example scripts for various customization of STORM (e.g., use your favorite language models, use your own corpus, etc.). These examples can be starting points for your own customizations and you are welcome to contribute your own examples by submitting a pull request to this directory.
 
 ## Run STORM with your own language model
-[run_storm_wiki_gpt.py](run_storm_wiki_gpt.py) provides an example of running STORM with GPT models, [run_storm_wiki_claude.py](run_storm_wiki_claude.py) provides an example of running STORM with Claude models, and [run_storm_wiki_minimax.py](run_storm_wiki_minimax.py) provides an example of running STORM with [MiniMax](https://www.minimaxi.com/) models (MiniMax-M2.5, MiniMax-M2.5-highspeed). Besides using close-source models, you can also run STORM with models with open weights.
+[run_storm_wiki_gpt.py](run_storm_wiki_gpt.py) provides an example of running STORM with GPT models, [run_storm_wiki_claude.py](run_storm_wiki_claude.py) provides an example of running STORM with Claude models, and [run_storm_wiki_minimax.py](run_storm_wiki_minimax.py) provides an example of running STORM with [MiniMax](https://www.minimaxi.com/) models (MiniMax-M2.7, MiniMax-M2.7-highspeed, MiniMax-M2.5, MiniMax-M2.5-highspeed). Besides using close-source models, you can also run STORM with models with open weights.
 
 `run_storm_wiki_mistral.py` provides an example of running STORM with `Mistral-7B-Instruct-v0.2` using [VLLM](https://docs.vllm.ai/en/stable/) server:
 

--- a/examples/storm_examples/README.md
+++ b/examples/storm_examples/README.md
@@ -3,7 +3,7 @@
 We host a number of example scripts for various customization of STORM (e.g., use your favorite language models, use your own corpus, etc.). These examples can be starting points for your own customizations and you are welcome to contribute your own examples by submitting a pull request to this directory.
 
 ## Run STORM with your own language model
-[run_storm_wiki_gpt.py](run_storm_wiki_gpt.py) provides an example of running STORM with GPT models, and [run_storm_wiki_claude.py](run_storm_wiki_claude.py) provides an example of running STORM with Claude models. Besides using close-source models, you can also run STORM with models with open weights.
+[run_storm_wiki_gpt.py](run_storm_wiki_gpt.py) provides an example of running STORM with GPT models, [run_storm_wiki_claude.py](run_storm_wiki_claude.py) provides an example of running STORM with Claude models, and [run_storm_wiki_minimax.py](run_storm_wiki_minimax.py) provides an example of running STORM with [MiniMax](https://www.minimaxi.com/) models (MiniMax-M2.5, MiniMax-M2.5-highspeed). Besides using close-source models, you can also run STORM with models with open weights.
 
 `run_storm_wiki_mistral.py` provides an example of running STORM with `Mistral-7B-Instruct-v0.2` using [VLLM](https://docs.vllm.ai/en/stable/) server:
 

--- a/examples/storm_examples/README.md
+++ b/examples/storm_examples/README.md
@@ -3,7 +3,7 @@
 We host a number of example scripts for various customization of STORM (e.g., use your favorite language models, use your own corpus, etc.). These examples can be starting points for your own customizations and you are welcome to contribute your own examples by submitting a pull request to this directory.
 
 ## Run STORM with your own language model
-[run_storm_wiki_gpt.py](run_storm_wiki_gpt.py) provides an example of running STORM with GPT models, [run_storm_wiki_claude.py](run_storm_wiki_claude.py) provides an example of running STORM with Claude models, and [run_storm_wiki_minimax.py](run_storm_wiki_minimax.py) provides an example of running STORM with [MiniMax](https://www.minimaxi.com/) models (MiniMax-M2.7, MiniMax-M2.7-highspeed, MiniMax-M2.5, MiniMax-M2.5-highspeed). Besides using close-source models, you can also run STORM with models with open weights.
+[run_storm_wiki_gpt.py](run_storm_wiki_gpt.py) provides an example of running STORM with GPT models, [run_storm_wiki_claude.py](run_storm_wiki_claude.py) provides an example of running STORM with Claude models, and [run_storm_wiki_minimax.py](run_storm_wiki_minimax.py) provides an example of running STORM with [MiniMax](https://www.minimaxi.com/) models (MiniMax-M3, MiniMax-M2.7, MiniMax-M2.7-highspeed). Besides using close-source models, you can also run STORM with models with open weights.
 
 `run_storm_wiki_mistral.py` provides an example of running STORM with `Mistral-7B-Instruct-v0.2` using [VLLM](https://docs.vllm.ai/en/stable/) server:
 

--- a/examples/storm_examples/run_storm_wiki_minimax.py
+++ b/examples/storm_examples/run_storm_wiki_minimax.py
@@ -76,8 +76,8 @@ def main(args):
         "top_p": args.top_p,
     }
 
-    # MiniMax offers 'MiniMax-M2.5' (standard) and 'MiniMax-M2.5-highspeed' (faster)
-    # Both models support up to 204K context window
+    # MiniMax offers 'MiniMax-M2.7' (latest flagship) and 'MiniMax-M2.7-highspeed' (faster)
+    # Previous models 'MiniMax-M2.5' and 'MiniMax-M2.5-highspeed' are also available
     conv_simulator_lm = MiniMaxModel(
         model=args.model, max_tokens=500, **minimax_kwargs
     )
@@ -190,9 +190,9 @@ if __name__ == "__main__":
     parser.add_argument(
         "--model",
         type=str,
-        choices=["MiniMax-M2.5", "MiniMax-M2.5-highspeed"],
-        default="MiniMax-M2.5",
-        help='MiniMax model to use. "MiniMax-M2.5" for standard tasks, "MiniMax-M2.5-highspeed" for faster inference.',
+        choices=["MiniMax-M2.7", "MiniMax-M2.7-highspeed", "MiniMax-M2.5", "MiniMax-M2.5-highspeed"],
+        default="MiniMax-M2.7",
+        help='MiniMax model to use. "MiniMax-M2.7" (latest flagship) for standard tasks, "MiniMax-M2.7-highspeed" for faster inference.',
     )
     parser.add_argument(
         "--temperature", type=float, default=1.0, help="Sampling temperature to use."

--- a/examples/storm_examples/run_storm_wiki_minimax.py
+++ b/examples/storm_examples/run_storm_wiki_minimax.py
@@ -76,8 +76,9 @@ def main(args):
         "top_p": args.top_p,
     }
 
-    # MiniMax offers 'MiniMax-M2.7' (latest flagship) and 'MiniMax-M2.7-highspeed' (faster)
-    # Previous models 'MiniMax-M2.5' and 'MiniMax-M2.5-highspeed' are also available
+    # MiniMax offers 'MiniMax-M3' (latest flagship, default) with 512K context window
+    # and image input support. Previous models 'MiniMax-M2.7' and 'MiniMax-M2.7-highspeed'
+    # are also available.
     conv_simulator_lm = MiniMaxModel(
         model=args.model, max_tokens=500, **minimax_kwargs
     )
@@ -190,9 +191,9 @@ if __name__ == "__main__":
     parser.add_argument(
         "--model",
         type=str,
-        choices=["MiniMax-M2.7", "MiniMax-M2.7-highspeed", "MiniMax-M2.5", "MiniMax-M2.5-highspeed"],
-        default="MiniMax-M2.7",
-        help='MiniMax model to use. "MiniMax-M2.7" (latest flagship) for standard tasks, "MiniMax-M2.7-highspeed" for faster inference.',
+        choices=["MiniMax-M3", "MiniMax-M2.7", "MiniMax-M2.7-highspeed"],
+        default="MiniMax-M3",
+        help='MiniMax model to use. "MiniMax-M3" (latest flagship, default) for standard tasks, "MiniMax-M2.7-highspeed" for faster inference.',
     )
     parser.add_argument(
         "--temperature", type=float, default=1.0, help="Sampling temperature to use."

--- a/examples/storm_examples/run_storm_wiki_minimax.py
+++ b/examples/storm_examples/run_storm_wiki_minimax.py
@@ -1,0 +1,257 @@
+"""
+STORM Wiki pipeline powered by MiniMax models and You.com or Bing search engine.
+You need to set up the following environment variables to run this script:
+    - MINIMAX_API_KEY: MiniMax API key (get one at https://www.minimaxi.com/)
+    - YDC_API_KEY: You.com API key; BING_SEARCH_API_KEY: Bing Search API key, SERPER_API_KEY: Serper API key, BRAVE_API_KEY: Brave API key, or TAVILY_API_KEY: Tavily API key
+
+Output will be structured as below
+args.output_dir/
+    topic_name/  # topic_name will follow convention of underscore-connected topic name w/o space and slash
+        conversation_log.json           # Log of information-seeking conversation
+        raw_search_results.json         # Raw search results from search engine
+        direct_gen_outline.txt          # Outline directly generated with LLM's parametric knowledge
+        storm_gen_outline.txt           # Outline refined with collected information
+        url_to_info.json                # Sources that are used in the final article
+        storm_gen_article.txt           # Final article generated
+        storm_gen_article_polished.txt  # Polished final article (if args.do_polish_article is True)
+"""
+
+import os
+import re
+import logging
+from argparse import ArgumentParser
+
+from knowledge_storm import (
+    STORMWikiRunnerArguments,
+    STORMWikiRunner,
+    STORMWikiLMConfigs,
+)
+from knowledge_storm.lm import MiniMaxModel
+from knowledge_storm.rm import (
+    YouRM,
+    BingSearch,
+    BraveRM,
+    SerperRM,
+    DuckDuckGoSearchRM,
+    TavilySearchRM,
+    SearXNG,
+)
+from knowledge_storm.utils import load_api_key
+
+
+def sanitize_topic(topic):
+    """
+    Sanitize the topic name for use in file names.
+    Remove or replace characters that are not allowed in file names.
+    """
+    # Replace spaces with underscores
+    topic = topic.replace(" ", "_")
+
+    # Remove any character that isn't alphanumeric, underscore, or hyphen
+    topic = re.sub(r"[^a-zA-Z0-9_-]", "", topic)
+
+    # Ensure the topic isn't empty after sanitization
+    if not topic:
+        topic = "unnamed_topic"
+
+    return topic
+
+
+def main(args):
+    load_api_key(toml_file_path="secrets.toml")
+    lm_configs = STORMWikiLMConfigs()
+
+    logger = logging.getLogger(__name__)
+
+    # Ensure MINIMAX_API_KEY is set
+    if not os.getenv("MINIMAX_API_KEY"):
+        raise ValueError(
+            "MINIMAX_API_KEY environment variable is not set. Please set it in your secrets.toml file."
+        )
+
+    minimax_kwargs = {
+        "api_key": os.getenv("MINIMAX_API_KEY"),
+        "api_base": os.getenv("MINIMAX_API_BASE", "https://api.minimax.io/v1"),
+        "temperature": args.temperature,
+        "top_p": args.top_p,
+    }
+
+    # MiniMax offers 'MiniMax-M2.5' (standard) and 'MiniMax-M2.5-highspeed' (faster)
+    # Both models support up to 204K context window
+    conv_simulator_lm = MiniMaxModel(
+        model=args.model, max_tokens=500, **minimax_kwargs
+    )
+    question_asker_lm = MiniMaxModel(
+        model=args.model, max_tokens=500, **minimax_kwargs
+    )
+    outline_gen_lm = MiniMaxModel(model=args.model, max_tokens=400, **minimax_kwargs)
+    article_gen_lm = MiniMaxModel(model=args.model, max_tokens=700, **minimax_kwargs)
+    article_polish_lm = MiniMaxModel(
+        model=args.model, max_tokens=4000, **minimax_kwargs
+    )
+
+    lm_configs.set_conv_simulator_lm(conv_simulator_lm)
+    lm_configs.set_question_asker_lm(question_asker_lm)
+    lm_configs.set_outline_gen_lm(outline_gen_lm)
+    lm_configs.set_article_gen_lm(article_gen_lm)
+    lm_configs.set_article_polish_lm(article_polish_lm)
+
+    engine_args = STORMWikiRunnerArguments(
+        output_dir=args.output_dir,
+        max_conv_turn=args.max_conv_turn,
+        max_perspective=args.max_perspective,
+        search_top_k=args.search_top_k,
+        max_thread_num=args.max_thread_num,
+    )
+
+    # STORM is a knowledge curation system which consumes information from the retrieval module.
+    # Currently, the information source is the Internet and we use search engine API as the retrieval module.
+    match args.retriever:
+        case "bing":
+            rm = BingSearch(
+                bing_search_api=os.getenv("BING_SEARCH_API_KEY"),
+                k=engine_args.search_top_k,
+            )
+        case "you":
+            rm = YouRM(ydc_api_key=os.getenv("YDC_API_KEY"), k=engine_args.search_top_k)
+        case "brave":
+            rm = BraveRM(
+                brave_search_api_key=os.getenv("BRAVE_API_KEY"),
+                k=engine_args.search_top_k,
+            )
+        case "duckduckgo":
+            rm = DuckDuckGoSearchRM(
+                k=engine_args.search_top_k, safe_search="On", region="us-en"
+            )
+        case "serper":
+            rm = SerperRM(
+                serper_search_api_key=os.getenv("SERPER_API_KEY"),
+                query_params={"autocorrect": True, "num": 10, "page": 1},
+            )
+        case "tavily":
+            rm = TavilySearchRM(
+                tavily_search_api_key=os.getenv("TAVILY_API_KEY"),
+                k=engine_args.search_top_k,
+                include_raw_content=True,
+            )
+        case "searxng":
+            rm = SearXNG(
+                searxng_api_key=os.getenv("SEARXNG_API_KEY"), k=engine_args.search_top_k
+            )
+        case _:
+            raise ValueError(
+                f'Invalid retriever: {args.retriever}. Choose either "bing", "you", "brave", "duckduckgo", "serper", "tavily", or "searxng"'
+            )
+
+    runner = STORMWikiRunner(engine_args, lm_configs, rm)
+
+    topic = input("Topic: ")
+    sanitized_topic = sanitize_topic(topic)
+
+    try:
+        runner.run(
+            topic=sanitized_topic,
+            do_research=args.do_research,
+            do_generate_outline=args.do_generate_outline,
+            do_generate_article=args.do_generate_article,
+            do_polish_article=args.do_polish_article,
+            remove_duplicate=args.remove_duplicate,
+        )
+        runner.post_run()
+        runner.summary()
+    except Exception as e:
+        logger.exception(f"An error occurred: {str(e)}")
+        raise
+
+
+if __name__ == "__main__":
+    parser = ArgumentParser()
+    # global arguments
+    parser.add_argument(
+        "--output-dir",
+        type=str,
+        default="./results/minimax",
+        help="Directory to store the outputs.",
+    )
+    parser.add_argument(
+        "--max-thread-num",
+        type=int,
+        default=3,
+        help="Maximum number of threads to use. The information seeking part and the article generation"
+        "part can speed up by using multiple threads. Consider reducing it if keep getting "
+        '"Exceed rate limit" error when calling LM API.',
+    )
+    parser.add_argument(
+        "--retriever",
+        type=str,
+        choices=["bing", "you", "brave", "serper", "duckduckgo", "tavily", "searxng"],
+        help="The search engine API to use for retrieving information.",
+    )
+    parser.add_argument(
+        "--model",
+        type=str,
+        choices=["MiniMax-M2.5", "MiniMax-M2.5-highspeed"],
+        default="MiniMax-M2.5",
+        help='MiniMax model to use. "MiniMax-M2.5" for standard tasks, "MiniMax-M2.5-highspeed" for faster inference.',
+    )
+    parser.add_argument(
+        "--temperature", type=float, default=1.0, help="Sampling temperature to use."
+    )
+    parser.add_argument(
+        "--top_p", type=float, default=0.9, help="Top-p sampling parameter."
+    )
+    # stage of the pipeline
+    parser.add_argument(
+        "--do-research",
+        action="store_true",
+        help="If True, simulate conversation to research the topic; otherwise, load the results.",
+    )
+    parser.add_argument(
+        "--do-generate-outline",
+        action="store_true",
+        help="If True, generate an outline for the topic; otherwise, load the results.",
+    )
+    parser.add_argument(
+        "--do-generate-article",
+        action="store_true",
+        help="If True, generate an article for the topic; otherwise, load the results.",
+    )
+    parser.add_argument(
+        "--do-polish-article",
+        action="store_true",
+        help="If True, polish the article by adding a summarization section and (optionally) removing "
+        "duplicate content.",
+    )
+    # hyperparameters for the pre-writing stage
+    parser.add_argument(
+        "--max-conv-turn",
+        type=int,
+        default=3,
+        help="Maximum number of questions in conversational question asking.",
+    )
+    parser.add_argument(
+        "--max-perspective",
+        type=int,
+        default=3,
+        help="Maximum number of perspectives to consider in perspective-guided question asking.",
+    )
+    parser.add_argument(
+        "--search-top-k",
+        type=int,
+        default=3,
+        help="Top k search results to consider for each search query.",
+    )
+    # hyperparameters for the writing stage
+    parser.add_argument(
+        "--retrieve-top-k",
+        type=int,
+        default=3,
+        help="Top k collected references for each section title.",
+    )
+    parser.add_argument(
+        "--remove-duplicate",
+        action="store_true",
+        help="If True, remove duplicate content from the article.",
+    )
+
+    main(parser.parse_args())

--- a/knowledge_storm/lm.py
+++ b/knowledge_storm/lm.py
@@ -462,12 +462,13 @@ class MiniMaxModel(dspy.OpenAI):
     """A wrapper class for MiniMax API (https://www.minimaxi.com/), compatible with dspy.OpenAI.
 
     MiniMax provides OpenAI-compatible chat completion endpoints.
-    Available models include 'MiniMax-M2.5' and 'MiniMax-M2.5-highspeed' (204K context window).
+    Available models include 'MiniMax-M2.7', 'MiniMax-M2.7-highspeed',
+    'MiniMax-M2.5' and 'MiniMax-M2.5-highspeed' (204K context window).
     """
 
     def __init__(
         self,
-        model: str = "MiniMax-M2.5",
+        model: str = "MiniMax-M2.7",
         api_key: Optional[str] = None,
         api_base: str = "https://api.minimax.io/v1",
         **kwargs,

--- a/knowledge_storm/lm.py
+++ b/knowledge_storm/lm.py
@@ -462,13 +462,14 @@ class MiniMaxModel(dspy.OpenAI):
     """A wrapper class for MiniMax API (https://www.minimaxi.com/), compatible with dspy.OpenAI.
 
     MiniMax provides OpenAI-compatible chat completion endpoints.
-    Available models include 'MiniMax-M2.7', 'MiniMax-M2.7-highspeed',
-    'MiniMax-M2.5' and 'MiniMax-M2.5-highspeed' (204K context window).
+    Available models include 'MiniMax-M3' (default, 512K context window,
+    up to 128K output, supports image input), 'MiniMax-M2.7' and
+    'MiniMax-M2.7-highspeed'.
     """
 
     def __init__(
         self,
-        model: str = "MiniMax-M2.7",
+        model: str = "MiniMax-M3",
         api_key: Optional[str] = None,
         api_base: str = "https://api.minimax.io/v1",
         **kwargs,

--- a/knowledge_storm/lm.py
+++ b/knowledge_storm/lm.py
@@ -458,6 +458,110 @@ class DeepSeekModel(dspy.OpenAI):
         return completions
 
 
+class MiniMaxModel(dspy.OpenAI):
+    """A wrapper class for MiniMax API (https://www.minimaxi.com/), compatible with dspy.OpenAI.
+
+    MiniMax provides OpenAI-compatible chat completion endpoints.
+    Available models include 'MiniMax-M2.5' and 'MiniMax-M2.5-highspeed' (204K context window).
+    """
+
+    def __init__(
+        self,
+        model: str = "MiniMax-M2.5",
+        api_key: Optional[str] = None,
+        api_base: str = "https://api.minimax.io/v1",
+        **kwargs,
+    ):
+        super().__init__(model=model, api_key=api_key, api_base=api_base, **kwargs)
+        self._token_usage_lock = threading.Lock()
+        self.prompt_tokens = 0
+        self.completion_tokens = 0
+        self.model = model
+        self.api_key = api_key or os.getenv("MINIMAX_API_KEY")
+        self.api_base = api_base
+        if not self.api_key:
+            raise ValueError(
+                "MiniMax API key must be provided either as an argument or as an environment variable MINIMAX_API_KEY"
+            )
+
+    def log_usage(self, response):
+        """Log the total tokens from the MiniMax API response."""
+        usage_data = response.get("usage")
+        if usage_data:
+            with self._token_usage_lock:
+                self.prompt_tokens += usage_data.get("prompt_tokens", 0)
+                self.completion_tokens += usage_data.get("completion_tokens", 0)
+
+    def get_usage_and_reset(self):
+        """Get the total tokens used and reset the token usage."""
+        usage = {
+            self.model: {
+                "prompt_tokens": self.prompt_tokens,
+                "completion_tokens": self.completion_tokens,
+            }
+        }
+        self.prompt_tokens = 0
+        self.completion_tokens = 0
+        return usage
+
+    @backoff.on_exception(
+        backoff.expo,
+        ERRORS,
+        max_time=1000,
+        on_backoff=backoff_hdlr,
+        giveup=giveup_hdlr,
+    )
+    def _create_completion(self, prompt: str, **kwargs):
+        """Create a completion using the MiniMax API."""
+        headers = {
+            "Content-Type": "application/json",
+            "Authorization": f"Bearer {self.api_key}",
+        }
+
+        # MiniMax requires temperature to be in (0.0, 1.0]; adjust if zero
+        if kwargs.get("temperature", 1) == 0:
+            kwargs["temperature"] = 0.01
+
+        data = {
+            "model": self.model,
+            "messages": [{"role": "user", "content": prompt}],
+            **kwargs,
+        }
+        response = requests.post(
+            f"{self.api_base}/chat/completions", headers=headers, json=data
+        )
+        response.raise_for_status()
+        return response.json()
+
+    def __call__(
+        self,
+        prompt: str,
+        only_completed: bool = True,
+        return_sorted: bool = False,
+        **kwargs,
+    ) -> list[dict[str, Any]]:
+        """Call the MiniMax API to generate completions."""
+        assert only_completed, "for now"
+        assert return_sorted is False, "for now"
+
+        response = self._create_completion(prompt, **kwargs)
+
+        # Log the token usage from the MiniMax API response.
+        self.log_usage(response)
+
+        choices = response["choices"]
+        completions = [choice["message"]["content"] for choice in choices]
+
+        history = {
+            "prompt": prompt,
+            "response": response,
+            "kwargs": kwargs,
+        }
+        self.history.append(history)
+
+        return completions
+
+
 class AzureOpenAIModel(dspy.LM):
     """A wrapper class of Azure OpenAI endpoint.
 


### PR DESCRIPTION
## Summary

This PR adds native support for [MiniMax](https://www.minimaxi.com/) LLM models in STORM, following the existing provider patterns (DeepSeek, Groq, etc.). The default model is `MiniMax-M3`, with `MiniMax-M2.7` and `MiniMax-M2.7-highspeed` kept as alternatives.

### Changes

- **`knowledge_storm/lm.py`**: Added `MiniMaxModel` class extending `dspy.OpenAI` with:
  - OpenAI-compatible API integration via `https://api.minimax.io/v1`
  - Support for `MiniMax-M3` (default, 512K context window, up to 128K max output, image input support), `MiniMax-M2.7`, and `MiniMax-M2.7-highspeed`
  - Token usage tracking and exponential backoff retry logic
  - Temperature clamping for API compatibility

- **`examples/storm_examples/run_storm_wiki_minimax.py`**: Full example script with CLI argument support for model selection, retriever choice, and pipeline stages

- **`README.md`** & **`examples/storm_examples/README.md`**: Updated documentation with MiniMax usage instructions

### Why

`MiniMax-M3` is the latest flagship model, featuring a 512K context window, up to 128K max output tokens, and image input support. This PR enables STORM users to leverage MiniMax models for knowledge curation, with M3 as the default and M2.7 family retained for backwards compatibility.

### Testing

- Verified API connectivity and completion generation
- All model choices work correctly with the CLI interface