### PR TITLE
fix: specify UTF-8 encoding for file I/O to prevent UnicodeEncodeError on Windows

### DIFF
--- a/examples/costorm_examples/run_costorm_gpt.py
+++ b/examples/costorm_examples/run_costorm_gpt.py
@@ -199,17 +199,17 @@ def main(args):
     os.makedirs(args.output_dir, exist_ok=True)
 
     # Save article
-    with open(os.path.join(args.output_dir, "report.md"), "w") as f:
+    with open(os.path.join(args.output_dir, "report.md"), "w", encoding="utf-8") as f:
         f.write(article)
 
     # Save instance dump
     instance_copy = costorm_runner.to_dict()
-    with open(os.path.join(args.output_dir, "instance_dump.json"), "w") as f:
+    with open(os.path.join(args.output_dir, "instance_dump.json"), "w", encoding="utf-8") as f:
         json.dump(instance_copy, f, indent=2)
 
     # Save logging
     log_dump = costorm_runner.dump_logging_and_reset()
-    with open(os.path.join(args.output_dir, "log.json"), "w") as f:
+    with open(os.path.join(args.output_dir, "log.json"), "w", encoding="utf-8") as f:
         json.dump(log_dump, f, indent=2)
 
 

--- a/knowledge_storm/storm_wiki/engine.py
+++ b/knowledge_storm/storm_wiki/engine.py
@@ -300,7 +300,7 @@ class STORMWikiRunner(Engine):
 
         llm_call_history = self.lm_configs.collect_and_reset_lm_history()
         with open(
-            os.path.join(self.article_output_dir, "llm_call_history.jsonl"), "w"
+            os.path.join(self.article_output_dir, "llm_call_history.jsonl"), "w", encoding="utf-8"
         ) as f:
             for call in llm_call_history:
                 if "kwargs" in call:

--- a/knowledge_storm/utils.py
+++ b/knowledge_storm/utils.py
@@ -610,13 +610,13 @@ class FileIOHelper:
             return json.load(fr)
 
     @staticmethod
-    def write_str(s, path):
-        with open(path, "w") as f:
+    def write_str(s, path, encoding="utf-8"):
+        with open(path, "w", encoding=encoding) as f:
             f.write(s)
 
     @staticmethod
-    def load_str(path):
-        with open(path, "r") as f:
+    def load_str(path, encoding="utf-8"):
+        with open(path, "r", encoding=encoding) as f:
             return "\n".join(f.readlines())
 
     @staticmethod


### PR DESCRIPTION
Fixes #352

## Problem

On Windows, Python uses the system default encoding (e.g. `cp1252`) when opening files without an explicit encoding. This encoding cannot represent many Unicode characters such as Greek letters (`β`, `α`, `μ`, etc.), causing `UnicodeEncodeError` when STORM generates articles containing such characters.

Example error:
```
UnicodeEncodeError: 'charmap' codec can't encode character '\u03b2' in position 2116: character maps to <undefined>
```

## Solution

Added `encoding="utf-8"` to all file open calls that were missing it:

- `FileIOHelper.write_str()` in `knowledge_storm/utils.py` — used to write article `.md` files and outlines
- `FileIOHelper.load_str()` in `knowledge_storm/utils.py` — used to read saved articles
- LLM call history write in `knowledge_storm/storm_wiki/engine.py`
- Output file writes in `examples/costorm_examples/run_costorm_gpt.py`

The `encoding` parameter is exposed as an optional argument with `"utf-8"` as the default, maintaining backward compatibility.

## Testing

The fix ensures consistent UTF-8 encoding across all platforms (Windows, macOS, Linux), preventing encoding errors when articles contain non-ASCII characters like Greek letters, Chinese characters, or other Unicode symbols.