### PR TITLE
fix: add '/' to allowed characters in topic input validation

### DIFF
--- a/knowledge_storm/utils.py
+++ b/knowledge_storm/utils.py
@@ -722,7 +722,7 @@ def user_input_appropriateness_check(user_input):
     if len(user_input.split()) > 20:
         return "The input is too long. Please make your input topic more concise!"
 
-    if not re.match(r'^[a-zA-Z0-9\s\-"\,\.?\']*$', user_input):
+    if not re.match(r'^[a-zA-Z0-9\s\-"/\,\.?\']*$', user_input):
         return "The input contains invalid characters. The input should only contain a-z, A-Z, 0-9, space, -/\"/,./?/'."
 
     prompt = f"""Here is a topic input into a knowledge curation engine that can write a Wikipedia-like article for the topic. Please judge whether it is appropriate or not for the engine to curate information for this topic based on English search engine. The following types of inputs are inappropriate:


### PR DESCRIPTION
Fixes #338

## Problem

The input validation regex in `knowledge_storm/utils.py` was missing the `/` character, even though the error message explicitly listed `/` as an allowed character:

> The input should only contain a-z, A-Z, 0-9, space, -/"/,./?/'.

This caused valid topic queries like `SARS COV -2 /` to be incorrectly rejected with the "invalid characters" error.

**Before:**
```python
if not re.match(r'^[a-zA-Z0-9\s\-"\,\.?\']*$', user_input):
```

**After:**
```python
if not re.match(r'^[a-zA-Z0-9\s\-"/\,\.?\']*$', user_input):
```

## Solution

Added `/` to the character class in the regex so it matches what the error message already documents as allowed.

## Testing

Verified locally:
- `SARS COV -2 /` → now passes validation ✓
- `COVID-19/SARS` → now passes validation ✓
- `Hello @ World` → still correctly rejected ✓