### PR TITLE
fix: use model_dump() in AzureOpenAIModel to prevent JSON serialization error

### DIFF
--- a/knowledge_storm/lm.py
+++ b/knowledge_storm/lm.py
@@ -524,7 +524,7 @@ class AzureOpenAIModel(dspy.LM):
 
             history_entry = {
                 "prompt": prompt,
-                "response": dict(response),
+                "response": response.model_dump(),
                 "kwargs": kwargs,
             }
             self.history.append(history_entry)


### PR DESCRIPTION
Fixes #353

## Problem

`AzureOpenAIModel.basic_request()` stores the API response in the LLM call history using `dict(response)`. The OpenAI SDK returns a `ChatCompletion` Pydantic v2 model, and calling `dict()` on it does **not** recursively convert nested objects — the `choices` field retains `Choice` objects rather than plain dicts.

When `post_run()` calls `json.dumps()` on each history entry to write `llm_call_history.jsonl`, this raises:

```
TypeError: Object of type Choice is not JSON serializable
```

## Solution

Replace `dict(response)` with `response.model_dump()`, which performs a full recursive conversion of the Pydantic model to plain Python dicts. This is consistent with:
- `GoogleModel`, which uses `response.to_dict()`
- The fix in #417 for `VLLMClient`, which uses `response.model_dump()`

## Testing

- Verified that `dict()` on a nested Pydantic v2 model leaves inner objects unconverted while `model_dump()` produces fully JSON-serializable output
- The fix is a one-line change in `AzureOpenAIModel.basic_request()` with no behavioral impact on completions